### PR TITLE
Parachutes cluttering the ground since Arma Update 112555

### DIFF
--- a/WAI/compile/heli_para.sqf
+++ b/WAI/compile/heli_para.sqf
@@ -80,6 +80,7 @@ _unitGroup setCombatMode "RED";
 _wp = _unitGroup addWaypoint [[(_position select 0), (_position select 1)], 0];
 _wp setWaypointType "MOVE";
 _wp setWaypointCompletionRadius 100;
+_DeleteP=[];
 
 _drop = True;
 _helipos = getpos _helicopter;
@@ -151,6 +152,7 @@ while {(alive _helicopter) AND (_drop)} do {
 			ai_ground_units = (ai_ground_units + 1);
 			_para addEventHandler ["Killed",{[_this select 0, _this select 1, "ground"] call on_kill;}];
 			_chute = createVehicle ["ParachuteEast", [(_helipos select 0), (_helipos select 1), (_helipos select 2)], [], 0, "NONE"];
+			_DeleteP=_DeleteP + [_chute];			
 			_para moveInDriver _chute;
 			[_para] joinSilent _pgroup;
 			sleep 1.5;
@@ -190,6 +192,6 @@ if (_helipatrol) then {
 	};
 };
 
-
-	
+sleep 45;
+{deleteVehicle _x} forEach _DeleteP;	
 	


### PR DESCRIPTION
Since the latest Arma 2 patch, (112555), the para_drop chutes are no
longer deleting when the AI land on our server. These changes set up an
array to collect every _chute created, then at the end of the script it
waits 45 seconds, (for the AI to safely land on the ground), then
deletes all of the _chutes. I've only seen a couple mentions of this on the various forums I go to so I am not sure if this issue is local to just a few setups or not. If global issue with 112555, this will fix the issue.
